### PR TITLE
fix: Enforce minimum vertex count for Polygons

### DIFF
--- a/src/main/java/de/chaffic/geometry/Polygon.kt
+++ b/src/main/java/de/chaffic/geometry/Polygon.kt
@@ -42,8 +42,12 @@ class Polygon : Shape {
      * The constructor automatically computes the convex hull of the given vertices to ensure the polygon is convex.
      *
      * @param vertList An array of [Vec2] points representing the vertices of the polygon.
+     * @throws IllegalArgumentException if the number of vertices is less than 3.
      */
     constructor(vertList: Array<Vec2>) {
+        if (vertList.size < 3) {
+            throw IllegalArgumentException("A polygon must have at least 3 vertices.")
+        }
         vertices = generateHull(vertList, vertList.size)
         calcNormals()
     }


### PR DESCRIPTION
This commit adds a check to the `Polygon` constructor that takes a list of vertices. It now throws an `IllegalArgumentException` if the provided list contains fewer than 3 vertices.

This prevents the creation of invalid `Polygon` objects, which could lead to unexpected behavior or crashes in the physics simulation. The KDoc for the constructor has also been updated to reflect this change.

## Summary by Sourcery

Enforce a minimum of three vertices in the Polygon constructor to prevent creation of invalid polygons

Bug Fixes:
- Throw IllegalArgumentException in Polygon constructor when fewer than three vertices are provided

Documentation:
- Update constructor KDoc to document the minimum vertex count exception