### PR TITLE
refactor: Change RayAngleInformation to a data class

### DIFF
--- a/src/main/java/de/chaffic/rays/ShadowCasting.kt
+++ b/src/main/java/de/chaffic/rays/ShadowCasting.kt
@@ -113,4 +113,4 @@ class ShadowCasting(var startPoint: Vec2, private val distance: Double) {
  * @param ray The [Ray] object.
  * @param angle The angle of the ray, used for sorting.
  */
-class RayAngleInformation(val ray: Ray, val angle: Double)
+data class RayAngleInformation(val ray: Ray, val angle: Double)


### PR DESCRIPTION
This commit refactors the `RayAngleInformation` class in `ShadowCasting.kt` to be a `data class`.

This is a more idiomatic use of Kotlin for a class that primarily holds data. It provides useful generated methods like `equals()`, `hashCode()`, and `toString()` for free, making the code cleaner and more robust.

## Summary by Sourcery

Enhancements:
- Refactor RayAngleInformation into a data class to auto-generate equals, hashCode, and toString